### PR TITLE
Center flexible length text & clear manualCaptureInput on open

### DIFF
--- a/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js
+++ b/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js
@@ -181,13 +181,13 @@ function drawText(text, fontWeight = 0.04, color = "#ffffff", showBackRect = tru
   let offsetY = (Math.max(dimension.width, dimension.height) * 0.01);
   let offsetX = (Math.max(dimension.width, dimension.height) * 0.02);
 
-  var x = (dimension.height / 2) - offsetX - (measured.width/3);
+  var x = (dimension.height - offsetX - measured.width)/2;
   var y = -((dimension.width / 2) - offsetY);
   var rotation = 90
 
   if (currentOrientation !== 0) {
     rotation = 0;
-    x = ((dimension.width / 2) - offsetY) - (measured.width/3);
+    x = (dimension.width - offsetY - measured.width)/2;
     y = (dimension.height / 2) - offsetX + (Math.max(dimension.width, dimension.height) * 0.04);
   }
 
@@ -505,6 +505,11 @@ var AcuantCamera = (function () {
             manualCaptureInput.accept = "image/*";
         }
         manualCaptureInput.onchange = onManualCapture;
+        // When capture is intitiated clearout the existing value to allow user to 
+        // re-upload the same image if desired.
+        manualCaptureInput.onclick = function(event) {
+          event.target.value = '';
+        }
         manualCaptureInput.click();
     }
 

--- a/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js
+++ b/SimpleHTMLApp/webSdk/dist/AcuantJavascriptWebSdk.js
@@ -508,7 +508,7 @@ var AcuantCamera = (function () {
         // When capture is intitiated clearout the existing value to allow user to 
         // re-upload the same image if desired.
         manualCaptureInput.onclick = function(event) {
-          event.target.value = '';
+          if(event && event.target) event.target.value = '';
         }
         manualCaptureInput.click();
     }


### PR DESCRIPTION
This PR carries two enhancements:
1. Horizontally center the new flexible length text within the view. Please note, this does _not_ account for text that is so long it would wrap onto a second line.
2. Clear `manualCaptureInput` value when manual capture is initiated. The file upload path only fires when the `manualCaptureInput` value changes (`manualCaptureInput.onchange`). There are times when a user may want to try to upload the same image more than once, this enhancement allows for that. 

Please note: The code base does not make it clear how the code is minified, so we were not able to update the minified file as well. If these updates are approved, we will need the minification to be run as well.

One other suggestion (that is not related to this PR): It seems that the code is either not being transpiled or is not being transpiled to allow to support that broad of an audience. It seem like the use of arrow functions (`=>`) is causing some browsers to throw irrecoverable errors. Would it be possible to add a fix for this (if we had access to your build pipeline/tooling we could help contribute here as well). 